### PR TITLE
Fixed Task 3_2 (Neo is redefined too early)

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/jvk2019/tasks/Task3_2.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/jvk2019/tasks/Task3_2.java
@@ -61,14 +61,15 @@ public abstract class Task3_2 extends TaskWithHelperFunctions {
     public abstract void solve();
 
     @Override
-    public boolean verify() {        
+    public boolean verify() {
+
+       if (!neo.isOnPhoneBooth()) {return false;}
         this.neo = new Neo(); //resetting looking direction to EAST
         turnRight();
         if(this.neo.getLookingDirection() != Direction.SOUTH) return false;
         turnRight();
         if(this.neo.getLookingDirection() != Direction.WEST) return false;
-        
-        
-        return neo.isOnPhoneBooth();
+		
+        return true;
     }
 }


### PR DESCRIPTION
Task 3_2 couldn't be completed successfully as the "neo" Object was redefined in the beginning of "verify()" for checking the "turnRicght()". The check if he's standing on the Phone is done on the wrong Object. This fixes it.